### PR TITLE
Minor updates.

### DIFF
--- a/client/diag.js
+++ b/client/diag.js
@@ -9,28 +9,31 @@
         .replace(/\*(.+?)\*/g, '<i>$1</i>')
   }
 
-  consumes = ['.diag-source']
+  consumes = ['.diag']
 
   emit = ($item, item) => {
     var emitTime = performance.now()
     $item[0].consuming = []
-    $item.addClass('diag-source')
+    $item.addClass('output-item')
     // some diagnostics...
     console.log('diag emit ' + item.id + ' at ' + emitTime )
     console.trace()
-    return  $item.append(`
+    $item.append(`
     <table>
       <tr><th>ID</th><td>${item.id}</td></tr>
       <tr><th>Emit Time</th><td>${emitTime}</td></tr>
     </table>
     <hr>`)
+    $item.dblclick(() => {
+      return wiki.textEditor($item, item);
+    })
   }
 
   bind = ($item, item) => {
     var bindTime = performance.now()
     $item.find('table').append(`
     <tr><th>Bind Time</th><td>${bindTime}</td></tr>`)
-    let toLeft = $(`.item:lt(${$('.item').index($item)})`).filter(".diag-source").last()
+    let toLeft = $(`.item:lt(${$('.item').index($item)})`).filter('.diag').last()
     console.log('diag bind ' + item.id + ' at ' + bindTime )
     console.trace()
     let toLeftID = toLeft.data('id')


### PR DESCRIPTION
* Add a double click handler so diag items can be removed from a page.
* Stop using -source for the consumes style as that convention is no
longer needed (though still supported).
* Add the output-item class to tag this plugin as one that does some
level of computation instead of just displaying user entered content.